### PR TITLE
Add support for ignoring selected addresses and ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DShield PFSense Client
 Convert pfsense firewall logs into dshield format for ingesting them into the dshield project
 
-This script *should* work in pfsense 2.2 and 2.3 but only has been tested currently with the most recent version (2.3.4-RELEASE-p1). It does **NEED** email configured on the pfsense notification setup. To adjust it, see System->Advanced->Notifications and the e-mail section.
+This script *should* work in pfsense 2.2 and 2.3 but only has been tested currently with the most recent 2.5.x releases as well as 2.3.4-RELEASE-p1. It does **NEED** email configured on the pfsense notification setup. To adjust it, see System->Advanced->Notifications and the e-mail section.
 
 ## Get the log converter script
 Place this PHP script in a convenient location ie: `/root/bin/dshieldpfsense.php`
@@ -42,6 +42,12 @@ chmod 770 /root/bin/dshieldpfsense.php/
 
 ## Debugging
 You will see messages left by the script in the system.log. To review, use:
+
+```
+cat /var/log/system.log | grep dshield
+```
+
+or, if running on a version before 2.5.0:
 
 ```
 clog /var/log/system.log | grep dshield

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Place this PHP script in a convenient location ie: `/root/bin/dshieldpfsense.php
   - ```curl https://raw.githubusercontent.com/jullrich/dshieldpfsense/master/dshield.php > /root/bin/dshieldpfsense.php```
 
 ## Editing necessary variables
-Before running it, modify the file to add the email address and the API key for your DShield account. You can find the API key here: https://www.dshield.org/myaccount.html
+Before running it, create the configuration file `dshield.ini` in the same location as the PHP script. Use `dshield.sample` as a template and customize settings as you wish.  At a minimum, you will need to use the email address and the API key for your DShield account. You can find the API key here: https://www.dshield.org/myaccount.html
 
 ```
 $authkey='--- insert authkey here. see dhsield.org/myaccount.html ---';
@@ -30,6 +30,19 @@ You need to know the alias name of your WAN interface. This can viewed at https:
 <p align="left">
   <img src="https://github.com/funtimes-ninja/dshieldpfsense/raw/master/images/interface.png" width="350"/>
 </p>
+
+## Excluding IP addresses and/or ports from reports
+If you wish, you can exclude certain source / target IP addresses (IPv4 only for now) and/or ports from being reported. To do that, uncomment one or more of the lines below :
+
+```
+#source_exclude=/root/etc/dshield-source-exclude.lst
+#source_port_exclude=/root/etc/dshield-source-port-exclude.lst
+#target_exclude=/root/etc/dshield-target-exclude.lst
+#target_port_exclude=/root/etc/dshield-target-port-exclude.lst
+```
+
+and edit the relevant file so it contains the exclusions you want. Lines starting with a `#` are regarded as comments and ignored; otherwise, each should specify either a single address (port) or a range of addresses (ports). Additionally, IP addresses should be specified using either CIDR notation (eg, `10.1.0.0/16`), a range (eg, `10.1.0.0 - 10.1.255.255`), or a single address (eg, `10.1.2.3`).
+
 
 ## Ensure the script is executable
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This script *should* work in pfsense 2.2 and 2.3 but only has been tested curren
 ## Get the log converter script
 Place this PHP script in a convenient location ie: `/root/bin/dshieldpfsense.php`
 
-1. You can copy & paste the contents of the php script if you have an SSH session on your pfsesne box.
+1. You can copy & paste the contents of the php script if you have an SSH session on your pfsense box.
 2. Another approach would be to scp the file to the server. If you want to use scp, remember that you must scp as root and not admin.      The admin account does not have privileges to put files on the system.
 3. You can curl the script onto the pfsense box.
   - ```curl https://raw.githubusercontent.com/jullrich/dshieldpfsense/master/dshield.php > /root/bin/dshieldpfsense.php```

--- a/dshield.sample
+++ b/dshield.sample
@@ -11,3 +11,8 @@ interfaces="WAN"
 debug=0
 #prevent auto ban ...
 authorized_source_ip="172.16.0.60,10.0.0.100"
+# Filter output by source / target and ip / port if desired.
+#source_exclude=/root/etc/dshield-source-exclude.lst
+#source_port_exclude=/root/etc/dshield-source-port-exclude.lst
+#target_exclude=/root/etc/dshield-target-exclude.lst
+#target_port_exclude=/root/etc/dshield-target-port-exclude.lst


### PR DESCRIPTION
I've added code to dshieldpfsense.php to support excluding selected IP addresses and ports from reports, similar to how the Linux iptable client works. [The code does not, unfortunately, support IPv6 address exclusions at the moment.]

I've also updated dshield.sample and README.md to reflect the changes and fix some other minor issues.